### PR TITLE
Update github actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -25,7 +25,7 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -
                 uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Current github actions/checkout v3 got error:

```

Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_4ecd32f5-c361-435e-b74b-7171ccb18414/3c125ce6-395a-4023-acd8-39fc47eba947.tar.gz. return code: 2.
```

Ref https://github.com/rectorphp/rector-src/actions/runs/6074243601/job/16477779233#step:1:35

It reported at:

- https://github.com/actions/checkout/issues/1448

This PR try to update to github actions/checkout v4.